### PR TITLE
-Fixes the broken thumbnail images of models in Oryx home

### DIFF
--- a/poem-jvm/data/database/thumbnail_fix.sql
+++ b/poem-jvm/data/database/thumbnail_fix.sql
@@ -1,0 +1,1 @@
+ALTER DATABASE poem SET bytea_output TO 'escape';

--- a/poem-jvm/src/java/org/b3mn/poem/handler/HandlerBase.java
+++ b/poem-jvm/src/java/org/b3mn/poem/handler/HandlerBase.java
@@ -140,8 +140,9 @@ public abstract class HandlerBase {
 	}
 	
 	// Returns the complete server path including the application e.g. 'http://localhost:8080/backend'
+	// getScheme() gets the protocol scheme being implemented. e.g. for oryx hosted on the website with ssl, 'https://..'
 	protected String getServerPath(HttpServletRequest req) {
-		return "http://" + req.getServerName() + ":" + String.valueOf(req.getServerPort()) + getRelativeServerPath(req);
+		return req.getScheme()+"://" + req.getServerName() + ":" + String.valueOf(req.getServerPort()) + getRelativeServerPath(req);
 	}
 	
 	protected String getRelativeServerPath(HttpServletRequest req){


### PR DESCRIPTION
-This is fix for the problem that occured after migrating to postgres 9.x versions

postgres@debian:~$ psql poem <  <path to oryx>/poem-jvm/data/database/thumbnail_fix.sql