### PR TITLE
-Fix for titles of the models.

### DIFF
--- a/editor/server/src/org/oryxeditor/server/EditorHandler.java
+++ b/editor/server/src/org/oryxeditor/server/EditorHandler.java
@@ -116,7 +116,7 @@ public class EditorHandler extends HttpServlet {
           	"</script>";
 		response.setContentType("application/xhtml+xml");
 		
-		response.getWriter().println(this.getOryxModel("Oryx-Editor", 
+		response.getWriter().println(this.getOryxModel(request.getParameter("title") != null ? request.getParameter("title") : "untitled", 
 				content, this.getLanguageCode(request), 
 				this.getCountryCode(request), profiles));
 		response.setStatus(200);

--- a/poem-jvm/src/java/org/b3mn/poem/handler/ModelHandler.java
+++ b/poem-jvm/src/java/org/b3mn/poem/handler/ModelHandler.java
@@ -80,8 +80,8 @@ public class ModelHandler extends  HandlerBase {
 
 	        }
 	    else{
-			response.sendRedirect("/oryx/editor;"+profileName+"#"+object.getUri());
-
+	    	Representation represent = object.read();
+	    	response.sendRedirect("/oryx/editor;"+profileName+"?title="+represent.getTitle()+"#"+object.getUri());
 	    }
 	}
 	


### PR DESCRIPTION
On creating and saving models, the title use to change in the title of the browser.
But then on closing and opening the browser title, use to be always "Oryx-Editor - Oryx",
This commit fixes that problem and now titles appear in the title bar with their name.