### PR TITLE
-Updated db_schema.sql for postgres9x

### DIFF
--- a/poem-jvm/data/database/db_schema.sql
+++ b/poem-jvm/data/database/db_schema.sql
@@ -689,11 +689,11 @@ ALTER FUNCTION public.friend_trigger_interaction() OWNER TO poem;
 -- Name: get_identity_from_hierarchy(text); Type: FUNCTION; Schema: public; Owner: poem
 --
 
-CREATE FUNCTION get_identity_from_hierarchy(hierarchy text) RETURNS identity
+CREATE FUNCTION get_identity_from_hierarchy(hierarchy_result text) RETURNS identity
     AS $$ DECLARE
 	result identity;
 BEGIN
-	SELECT identity.* INTO result FROM identity, structure WHERE identity.id=structure.ident_id AND structure.hierarchy=hierarchy;
+	SELECT identity.* INTO result FROM identity, structure WHERE identity.id=structure.ident_id AND structure.hierarchy=hierarchy_result;
 	RETURN result;
 END;$$
     LANGUAGE plpgsql;
@@ -705,11 +705,11 @@ ALTER FUNCTION public.get_identity_from_hierarchy(hierarchy text) OWNER TO poem;
 -- Name: get_identity_id_from_hierarchy(text); Type: FUNCTION; Schema: public; Owner: poem
 --
 
-CREATE FUNCTION get_identity_id_from_hierarchy(hierarchy text) RETURNS integer
+CREATE FUNCTION get_identity_id_from_hierarchy(hierarchy_results text) RETURNS integer
     AS $$ DECLARE
 	result integer;
 BEGIN
-	SELECT identity.id INTO result FROM identity, structure WHERE identity.id=structure.ident_id AND structure.hierarchy=hierarchy;
+	SELECT identity.id INTO result FROM identity, structure WHERE identity.id=structure.ident_id AND structure.hierarchy=hierarchy_results;
 	RETURN result;
 END;$$
     LANGUAGE plpgsql;


### PR DESCRIPTION
-In this commit, changed the functions, that were causing a problem of not being able to 'make the models public'.
-The older installations, must however run, ('no' need to do so for installations after this commit)
postgres@debian:~$ psql poem < /poem-jvm/data/database/migrate_to_p9x.sql (commit: #516)
to fix the bug.