### PR TITLE
-Title for Models

### DIFF
--- a/editor/server/src/org/oryxeditor/server/ProcessWaveEditorHandler.java
+++ b/editor/server/src/org/oryxeditor/server/ProcessWaveEditorHandler.java
@@ -79,7 +79,7 @@ public class ProcessWaveEditorHandler extends EditorHandler {
           	"</script>";
 		response.setContentType("application/xhtml+xml");
 		
-		response.getWriter().println(this.getOryxModel("Oryx-Editor", 
+		response.getWriter().println(this.getOryxModel(request.getParameter("title") != null ? request.getParameter("title") : "untitled", 
 				content, this.getLanguageCode(request), 
 				this.getCountryCode(request), profileName(sset)));
 		response.setStatus(200);


### PR DESCRIPTION
-The commit #529 fixes the problem for Oryx hosted on the local machine.
-However Oryx hosted on the server still do not display the title for models.
-Looked where else the title is being defined and fixed it.