### PR TITLE
-Fix for UML Class diagram broken thumbnails and export formats

### DIFF
--- a/editor/data/stencilsets/uml2.2/view/connectors/generalization.svg
+++ b/editor/data/stencilsets/uml2.2/view/connectors/generalization.svg
@@ -8,7 +8,7 @@
 	  </marker>
 	</defs>
 	<g id="edge">
-		<path d="M50 50 L100 50" stroke="black" fill="none" stroke-width="2" marker-end="url(#end)" marker-start="url(#begin)"/>
+		<path d="M50 50 L100 50" stroke="black" fill="none" stroke-width="2" marker-end="url(#end)"/>
 		<text id="name" x="0" y="0" oryx:edgePosition="midTop"/>
 		<text id="keyword" x="0" y="0" oryx:edgePosition="midBottom"/>
 	</g>

--- a/editor/data/stencilsets/umlusecase/view/edge.generalization.svg
+++ b/editor/data/stencilsets/umlusecase/view/edge.generalization.svg
@@ -25,7 +25,7 @@
 			stroke="black" fill="none" 
 			stroke-width="2" 
 			marker-end="url(#end)" 
-			marker-start="url(#begin)"/>
+			/>
 			
 		<text 
 			id="name" 


### PR DESCRIPTION
-The thumbnails were broken and exports had error because there was problem with "Generalization node"
-Fixed "Generalization" nodes of both UML Class Diagram and UML Use Case Diagram.